### PR TITLE
Add Railway deployment workflow

### DIFF
--- a/.github/workflows/railway-deploy.yml
+++ b/.github/workflows/railway-deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to Railway
+
+on:
+  push:
+    branches:
+      - main
+      - test
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Trigger Railway deployment
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install Railway CLI and deploy
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT: ${{ secrets.RAILWAY_ENVIRONMENT }}
+          RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RAILWAY_TOKEN}" ]; then
+            echo "Missing RAILWAY_TOKEN secret."
+            exit 1
+          fi
+
+          npm install -g @railway/cli
+
+          railway login --token "${RAILWAY_TOKEN}"
+
+          if [ -n "${RAILWAY_PROJECT_ID:-}" ]; then
+            railway link --project "${RAILWAY_PROJECT_ID}"
+          fi
+
+          deploy_command="railway up"
+
+          if [ -n "${RAILWAY_SERVICE:-}" ]; then
+            deploy_command="${deploy_command} --service ${RAILWAY_SERVICE}"
+          fi
+
+          if [ -n "${RAILWAY_ENVIRONMENT:-}" ]; then
+            deploy_command="${deploy_command} --environment ${RAILWAY_ENVIRONMENT}"
+          fi
+
+          echo "Running: ${deploy_command}"
+          eval "${deploy_command}"


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys to Railway automatically when pushing to the main or test branches
- install the Railway CLI within the workflow and run `railway up`, linking to the project when the optional secrets are provided

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d18c70d7bc8333a51a2b958378365d